### PR TITLE
Support LaTeX rendering of uncertainties in Jupyter frontends

### DIFF
--- a/scinum.py
+++ b/scinum.py
@@ -301,6 +301,10 @@ class Number(object):
         if uncertainties is not None:
             self.uncertainties = uncertainties
 
+        if not self.is_numpy:
+            # support for LaTeX rendering in Jupyter
+            setattr(self, '_repr_latex_', functools.partial(self.str, style="latex", si=True))
+
     @typed
     def nominal(self, nominal):
         # parser for the typed member holding the nominal value


### PR DESCRIPTION
This adds support for LaTeX rendering of uncertainties in Jupyter based frontends:
<img width="708" alt="bildschirmfoto 2018-02-21 um 09 52 05" src="https://user-images.githubusercontent.com/13285808/36471063-63b4e7e4-16ed-11e8-90fe-a591347e6adb.png">