### PR TITLE
Support ufuncs (NEP 13)

### DIFF
--- a/scinum.py
+++ b/scinum.py
@@ -440,6 +440,19 @@ class Number(object):
         uncertainties = self.__class__.uncertainties.fparse(self, {name: value})
         self._uncertainties.update(uncertainties)
 
+    def clear(self, nominal=None, uncertainties=None):
+        """
+        Removes all uncertainties and sets the nominal value to zero (float). When *nominal* and
+        *uncertainties* are given, these new values are set on this instance.
+        """
+        self.uncertainties = {}
+        self.nominal = 0.
+
+        if nominal is not None:
+            self.nominal = nominal
+        if uncertainties is not None:
+            self.uncertainties = uncertainties
+
     def str(self, format=None, unit=None, scientific=False, si=False, labels=True, style="plain",
             styles=None, force_asymmetric=False, **kwargs):
         r"""
@@ -593,7 +606,8 @@ class Number(object):
         if not self.is_numpy:
             text = "'" + self.str(*args, **kwargs) + "'"
         else:
-            text = "{} numpy array, {} uncertainties".format(self.shape, len(self.uncertainties))
+            text = "numpy array, shape {}, {} uncertainties".format(self.shape,
+                len(self.uncertainties))
 
         return "<{} at {}, {}>".format(self.__class__.__name__, hex(id(self)), text)
 
@@ -717,10 +731,33 @@ class Number(object):
                 nom1=num.nominal, nom2=other.nominal, rho=_rho) for i in range(2))
 
         # store values
-        num.nominal = nom
-        num.uncertainties = uncs
+        num.clear(nom, uncs)
 
         return num
+
+    def __array_ufunc__(self, ufunc, method, *inputs, **kwargs):
+        # only direct calls of the ufunc are supported
+        if method != "__call__":
+            return NotImplemented
+
+        # try to find the proper op for that ufunc
+        op = ops.get_ufunc_operation(ufunc)
+        if op is None:
+            return NotImplemented
+
+        # extract kwargs
+        out = kwargs.pop("out", None)
+
+        # apply the op
+        result = op(*inputs, **kwargs)
+
+        # insert in-place to an "out" object?
+        if out is not None:
+            out = out[0]
+            out.clear(result.nominal, result.uncertainties)
+            result = out
+
+        return result
 
     def __call__(self, *args, **kwargs):
         # shorthand for get
@@ -881,12 +918,13 @@ class Operation(object):
        The name of the operation.
     """
 
-    def __init__(self, function, derivative=None, name=None):
+    def __init__(self, function, derivative=None, name=None, ufunc_name=None):
         super(Operation, self).__init__()
 
         self.function = function
         self.derivative = derivative
         self._name = name or function.__name__
+        self._ufunc_name = ufunc_name
 
         # decorator for setting the derivative
         def derive(derivative):
@@ -897,6 +935,10 @@ class Operation(object):
     @property
     def name(self):
         return self._name
+
+    @property
+    def ufunc_name(self):
+        return self._ufunc_name
 
     def __repr__(self):
         return "<{} '{}' at {}>".format(self.__class__.__name__, self.name, hex(id(self)))
@@ -942,10 +984,14 @@ class ops(with_metaclass(OpsMeta, object)):
         print(num) # -> 25.00 (+10.00, -10.00)
     """
 
+    # registered operations mapped to their names
     _instances = {}
 
+    # mapping of ufunc names to operation names for faster lookup
+    _ufuncs = {}
+
     @classmethod
-    def register(cls, function=None, name=None):
+    def register(cls, function=None, name=None, ufunc=None):
         """
         Registers a new math function *function* with *name* and returns an :py:class:`Operation`
         instance. A math function expects a :py:class:`Number` as its first argument, followed by
@@ -971,13 +1017,25 @@ class ops(with_metaclass(OpsMeta, object)):
         Please note that there is no need to register *simple* functions as in the particular
         example above as most of them are just composite operations whose derivatives are already
         known.
+
+        To comply with NumPy's ufuncs (https://numpy.org/neps/nep-0013-ufunc-overrides.html) that
+        are handled by :py:meth:`Number.__array_ufunc__`, an operation might define a *ufunc* name
+        to signalize that it should be used when a ufunc with that name is called with a number
+        instance as its argument.
         """
+        ufunc_name = None
+        if ufunc is not None:
+            ufunc_name = ufunc if isinstance(ufunc, string_types) else ufunc.__name__
+
         def register(function):
             op = Operation(function, name=name, ufunc_name=ufunc_name)
 
             # save as class attribute and also in _instances
             cls._instances[op.name] = op
-            setattr(cls, op.name, staticmethod(wrapper))
+            setattr(cls, op.name, op)
+
+            # add to ufunc mapping
+            cls._ufuncs[op.ufunc_name] = op.name
 
             return op
 
@@ -1000,12 +1058,37 @@ class ops(with_metaclass(OpsMeta, object)):
         """
         return cls.get_operation(*args, **kwargs)
 
+    @classmethod
+    def get_ufunc_operation(cls, ufunc):
+        """
+        Returns an operation that was previously registered to handle a NumPy *ufunc*, which can be
+        a string or the function itself. *None* is returned when no operation was found to handle
+        the function.
+        """
+        ufunc_name = ufunc if isinstance(ufunc, string_types) else ufunc.__name__
+
+        if ufunc_name not in cls._ufuncs:
+            return None
+
+        op_name = cls._ufuncs[ufunc_name]
+        return cls.get_operation(op_name)
+
+    @classmethod
+    def rebuilt_ufunc_cache(cls):
+        """
+        Rebuilts the internal cache of ufuncs.
+        """
+        cls._ufuncs.clear()
+        for name, op in cls._instances.items():
+            if op.ufunc_name:
+                cls._ufuncs[op.ufunc_name] = name
+
 
 #
 # Pre-registered operations.
 #
 
-@ops.register
+@ops.register(ufunc="add")
 def add(x, n):
     """ add(x, n)
     Addition function.
@@ -1018,7 +1101,7 @@ def add(x, n):
     return 1.
 
 
-@ops.register
+@ops.register(ufunc="subtract")
 def sub(x, n):
     """ sub(x, n)
     Subtraction function.
@@ -1031,7 +1114,7 @@ def sub(x, n):
     return 1.
 
 
-@ops.register
+@ops.register(ufunc="multiply")
 def mul(x, n):
     """ mul(x, n)
     Multiplication function.
@@ -1044,7 +1127,7 @@ def mul(x, n):
     return n
 
 
-@ops.register
+@ops.register(ufunc="divide")
 def div(x, n):
     """ div(x, n)
     Division function.
@@ -1057,7 +1140,7 @@ def div(x, n):
     return 1. / n
 
 
-@ops.register
+@ops.register(ufunc="power")
 def pow(x, n):
     """ pow(x, n)
     Power function.
@@ -1070,7 +1153,7 @@ def pow(x, n):
     return n * x**(n - 1.)
 
 
-@ops.register
+@ops.register(ufunc="exp")
 def exp(x):
     """ exp(x)
     Exponential function.
@@ -1081,7 +1164,7 @@ def exp(x):
 exp.derivative = exp.function
 
 
-@ops.register
+@ops.register(ufunc="log")
 def log(x, base=None):
     """ log(x, base=e)
     Logarithmic function.
@@ -1104,7 +1187,33 @@ def log(x, base=None):
         return 1. / (x * infer_math(x).log(base))
 
 
-@ops.register
+@ops.register(ufunc="log10")
+def log10(x):
+    """ log10(x)
+    Logarithmic function with base 10.
+    """
+    return log.function(x, base=10.)
+
+
+@log10.derive
+def log10(x):
+    return log.derivative(x, base=10.)
+
+
+@ops.register(ufunc="log2")
+def log2(x):
+    """ log2(x)
+    Logarithmic function with base 2.
+    """
+    return log.function(x, base=2.)
+
+
+@log2.derive
+def log2(x):
+    return log.derivative(x, base=2.)
+
+
+@ops.register(ufunc="sqrt")
 def sqrt(x):
     """ sqrt(x)
     Square root function.
@@ -1117,7 +1226,7 @@ def sqrt(x):
     return 1. / (2 * infer_math(x).sqrt(x))
 
 
-@ops.register
+@ops.register(ufunc="sin")
 def sin(x):
     """ sin(x)
     Trigonometric sin function.
@@ -1130,7 +1239,7 @@ def sin(x):
     return infer_math(x).cos(x)
 
 
-@ops.register
+@ops.register(ufunc="cos")
 def cos(x):
     """ cos(x)
     Trigonometric cos function.
@@ -1143,7 +1252,7 @@ def cos(x):
     return -infer_math(x).sin(x)
 
 
-@ops.register
+@ops.register(ufunc="tan")
 def tan(x):
     """ tan(x)
     Trigonometric tan function.
@@ -1156,7 +1265,7 @@ def tan(x):
     return 1. / infer_math(x).cos(x)**2.
 
 
-@ops.register
+@ops.register(ufunc="arcsin")
 def asin(x):
     """ asin(x)
     Trigonometric arc sin function.
@@ -1173,7 +1282,7 @@ def asin(x):
     return 1. / infer_math(x).sqrt(1 - x**2.)
 
 
-@ops.register
+@ops.register(ufunc="arccos")
 def acos(x):
     """ acos(x)
     Trigonometric arc cos function.
@@ -1190,7 +1299,7 @@ def acos(x):
     return -1. / infer_math(x).sqrt(1 - x**2.)
 
 
-@ops.register
+@ops.register(ufunc="arctan")
 def atan(x):
     """ tan(x)
     Trigonometric arc tan function.
@@ -1207,7 +1316,7 @@ def atan(x):
     return 1. / (1 + x**2.)
 
 
-@ops.register
+@ops.register(ufunc="sinh")
 def sinh(x):
     """ sinh(x)
     Hyperbolic sin function.
@@ -1220,7 +1329,7 @@ def sinh(x):
     return infer_math(x).cosh(x)
 
 
-@ops.register
+@ops.register(ufunc="cosh")
 def cosh(x):
     """ cosh(x)
     Hyperbolic cos function.
@@ -1233,7 +1342,7 @@ def cosh(x):
     return infer_math(x).sinh(x)
 
 
-@ops.register
+@ops.register(ufunc="tanh")
 def tanh(x):
     """ tanh(x)
     Hyperbolic tan function.
@@ -1246,7 +1355,7 @@ def tanh(x):
     return 1. / infer_math(x).cosh(x)**2.
 
 
-@ops.register
+@ops.register(ufunc="arcsinh")
 def asinh(x):
     """ asinh(x)
     Hyperbolic arc sin function.
@@ -1258,7 +1367,7 @@ def asinh(x):
         return _math.arcsinh(x)
 
 
-@ops.register
+@ops.register(ufunc="arccosh")
 def acosh(x):
     """ acosh(x)
     Hyperbolic arc cos function.
@@ -1274,7 +1383,7 @@ asinh.derivative = acosh.function
 acosh.derivative = asinh.function
 
 
-@ops.register
+@ops.register(ufunc="arctanh")
 def atanh(x):
     """ atanh(x)
     Hyperbolic arc tan function.

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -291,10 +291,10 @@ class TestCase(unittest.TestCase):
         self.assertAlmostEqual(num.u("C", DOWN), 3.)
 
         num = np.exp(Number(np.array([1., 2.]), 3.))
-        self.assertAlmostEqual(num.nominal[0], 2.718282, 6)
-        self.assertAlmostEqual(num.nominal[1], 7.389056, 6)
-        self.assertAlmostEqual(num.get(UP)[0], 10.873127, 6)
-        self.assertAlmostEqual(num.get(UP)[1], 29.556225, 6)
+        self.assertAlmostEqual(num.nominal[0], 2.71828, 4)
+        self.assertAlmostEqual(num.nominal[1], 7.38906, 4)
+        self.assertAlmostEqual(num.get(UP)[0], 10.87313, 4)
+        self.assertAlmostEqual(num.get(UP)[1], 29.55623, 4)
 
     def test_op_pow(self):
         num = ops.pow(self.num, 2)

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -265,7 +265,7 @@ class TestCase(unittest.TestCase):
 
         self.assertFalse("foo" in ops)
 
-        @ops.register
+        @ops.register(ufunc="abc")
         def foo(x, a, b, c):
             return a + b * x + c * x ** 2
 
@@ -273,11 +273,28 @@ class TestCase(unittest.TestCase):
         self.assertEqual(ops.get_operation("foo"), foo)
         self.assertIsNone(foo.derivative)
 
+        self.assertEqual(foo.ufunc_name, "abc")
+        self.assertEqual(ops.get_ufunc_operation("abc"), foo)
+
         @foo.derive
         def foo(x, a, b, c):
             return b + 2 * c * x
 
         self.assertTrue(callable(foo.derivative))
+
+    @if_numpy
+    def test_ufuncs(self):
+        num = np.multiply(self.num, 2)
+        self.assertAlmostEqual(num(), self.num() * 2.)
+        self.assertAlmostEqual(num.u("A", UP), 1.)
+        self.assertAlmostEqual(num.u("B", UP), 2.)
+        self.assertAlmostEqual(num.u("C", DOWN), 3.)
+
+        num = np.exp(Number(np.array([1., 2.]), 3.))
+        self.assertAlmostEqual(num.nominal[0], 2.718282, 6)
+        self.assertAlmostEqual(num.nominal[1], 7.389056, 6)
+        self.assertAlmostEqual(num.get(UP)[0], 10.873127, 6)
+        self.assertAlmostEqual(num.get(UP)[1], 29.556225, 6)
 
     def test_op_pow(self):
         num = ops.pow(self.num, 2)


### PR DESCRIPTION
This PR enables numpy ufunc support for `Number`s:

```python
import numpy as np
from scinum import Number

num = Number(np.array([1, 2]), {"my_error": np.array([0.5, 0.5])})
print(num)
# [1. 2.]
# + my_error [0.5 0.5]
# - my_error [0.5 0.5]

print(np.sin(num))
# [0.84147096 0.9092974 ]
# + my_error [0.27015114 0.20807342]
# - my_error [0.27015114 0.20807342]
```

Closes #7.