### PR TITLE
Add fancy style using "±" instead of "+-"

### DIFF
--- a/.github/workflows/lint_and_test.yml
+++ b/.github/workflows/lint_and_test.yml
@@ -82,7 +82,6 @@ jobs:
       fail-fast: false
       matrix:
         python-version:
-          - "2.7"
           - "3.6"
     name: test (python ${{ matrix.python-version }})
     steps:

--- a/scinum.py
+++ b/scinum.py
@@ -242,15 +242,15 @@ class Number(object):
     .. code-block:: python
 
         num = Number(5, 1)
-        print(num + 2)  # -> '7.0 +- 1.0'
-        print(num * 3)  # -> '15.0 +- 3.0'
+        print(num + 2)  # -> '7.0 ±1.0'
+        print(num * 3)  # -> '15.0 ±3.0'
 
         num2 = Number(2.5, 1.5)
-        print(num + num2)  # -> '7.5 +- 1.80277563773'
-        print(num * num2)  # -> '12.5 +- 7.90569415042'
+        print(num + num2)  # -> '7.5 ±1.80277563773'
+        print(num * num2)  # -> '12.5 ±7.90569415042'
 
         num.add(num2, rho=1)
-        print(num)  # -> '7.5 +- 2.5'
+        print(num)  # -> '7.5 ±2.5'
 
     See :py:meth:`str` for information on string formatting.
 
@@ -643,23 +643,23 @@ class Number(object):
         .. code-block:: python
 
             n = Number(17.321, {"a": 1.158, "b": 0.453})
-            n.str()                    # -> '17.321 +- 1.158 (a) +- 0.453 (b)'
-            n.str("%.1f")              # -> '17.3 +- 1.2 (a) +- 0.5 (b)'
-            n.str("publication")       # -> '17.32 +- 1.16 (a) +- 0.45 (b)'
-            n.str("pdg")               # -> '17.3 +- 1.2 (a) +- 0.5 (b)'
+            n.str()                    # -> '17.321 ±1.158 (a) ±0.453 (b)'
+            n.str("%.1f")              # -> '17.3 ±1.2 (a) ±0.5 (b)'
+            n.str("publication")       # -> '17.32 ±1.16 (a) ±0.45 (b)'
+            n.str("pdg")               # -> '17.3 ±1.2 (a) ±0.5 (b)'
             n.str(combine_uncs="all")  # -> 'TODO'
 
             n = Number(8848, 10)
-            n.str(unit="m")                           # -> "8848.0 +- 10.0 m"
+            n.str(unit="m")                           # -> "8848.0 ±10.0 m"
             n.str(unit="m", force_asymmetric=True)    # -> "8848.0 +10.0-10.0 m"
-            n.str(unit="m", scientific=True)          # -> "8.848 +- 0.01 x 1E3 m"
-            n.str("%.2f", unit="m", scientific=True)  # -> "8.85 +- 0.01 x 1E3 m"
-            n.str(unit="m", si=True)                  # -> "8.848 +- 0.01 km"
-            n.str("%.2f", unit="m", si=True)          # -> "8.85 +- 0.01 km"
-            n.str(unit="m", style="latex")            # -> "8848.0 \pm 10.0\,m"
-            n.str(unit="m", style="latex", si=True)   # -> "8.848 \pm 0.01\,km"
-            n.str(unit="m", style="root")             # -> "8848.0 #pm 10.0 m"
-            n.str(unit="m", style="root", si=True)    # -> "8.848 #pm 0.01 km"
+            n.str(unit="m", scientific=True)          # -> "8.848 ±0.01 x 1E3 m"
+            n.str("%.2f", unit="m", scientific=True)  # -> "8.85 ±0.01 x 1E3 m"
+            n.str(unit="m", si=True)                  # -> "8.848 ±0.01 km"
+            n.str("%.2f", unit="m", si=True)          # -> "8.85 ±0.01 km"
+            n.str(unit="m", style="latex")            # -> "8848.0 \pm10.0\,m"
+            n.str(unit="m", style="latex", si=True)   # -> "8.848 \pm0.01\,km"
+            n.str(unit="m", style="root")             # -> "8848.0 #pm10.0 m"
+            n.str(unit="m", style="root", si=True)    # -> "8.848 #pm0.01 km"
         """
         if format is None:
             format = self.default_format or self.__class__.default_format
@@ -1240,14 +1240,14 @@ class DeferredResult(object):
         n = Number(2, 5)
 
         n * Correlation(1) * n
-        # -> '25.0 +- 20.0' (the default)
+        # -> '25.0 ±20.0' (the default)
 
         n * Correlation(0) * n
-        # -> '25.00 +- 14.14'
+        # -> '25.00 ±14.14'
 
         # note the multiplication n * c, which creates the DeferredResult
         n**(n * c)
-        # -> '3125.00 +- 11842.54'
+        # -> '3125.00 ±11842.54'
 
     .. py:attribute:: number
        type: Number
@@ -2621,7 +2621,7 @@ def create_hep_data_representer(method=None, force_asymmetric=False, force_float
 #:         "space": " ",
 #:         "label": "({label})",
 #:         "unit": " {unit}",
-#:         "sym": "+- {unc}",
+#:         "sym": "±{unc}",
 #:         "asym": "+{up}-{down}",
 #:         "sci": "x 1E{mag}",
 #:     }
@@ -2630,7 +2630,7 @@ style_dict = {
         "space": " ",
         "label": "({label})",
         "unit": " {unit}",
-        "sym": "+- {unc}",
+        "sym": "±{unc}",
         "asym": "+{up}-{down}",
         "sci": "x 1E{mag}",
     },
@@ -2638,7 +2638,7 @@ style_dict = {
         "space": r" ",
         "label": r"\left(\text{{{label}}}\right)",
         "unit": r"\,{unit}",
-        "sym": r"\pm {unc}",
+        "sym": r"\pm{unc}",
         "asym": r"\,^{{+{up}}}_{{-{down}}}",
         "sci": r"\times 10^{{{mag}}}",
     },
@@ -2646,7 +2646,7 @@ style_dict = {
         "space": " ",
         "label": "#left({label}#right)",
         "unit": " {unit}",
-        "sym": "#pm {unc}",
+        "sym": "#pm{unc}",
         "asym": "^{{+{up}}}_{{-{down}}}",
         "sci": "#times 10^{{{mag}}}",
     },

--- a/scinum.py
+++ b/scinum.py
@@ -242,15 +242,15 @@ class Number(object):
     .. code-block:: python
 
         num = Number(5, 1)
-        print(num + 2)  # -> '7.0 ±1.0'
-        print(num * 3)  # -> '15.0 ±3.0'
+        print(num + 2)  # -> '7.0 +-1.0'
+        print(num * 3)  # -> '15.0 +-3.0'
 
         num2 = Number(2.5, 1.5)
-        print(num + num2)  # -> '7.5 ±1.80277563773'
-        print(num * num2)  # -> '12.5 ±7.90569415042'
+        print(num + num2)  # -> '7.5 +-1.80277563773'
+        print(num * num2)  # -> '12.5 +-7.90569415042'
 
         num.add(num2, rho=1)
-        print(num)  # -> '7.5 ±2.5'
+        print(num)  # -> '7.5 +-2.5'
 
     See :py:meth:`str` for information on string formatting.
 
@@ -631,7 +631,8 @@ class Number(object):
 
         *labels* controls whether uncertainty labels are shown in the string. When *True*,
         uncertainty names are used, but it can also be a list of labels whose order should match the
-        uncertainty dict traversal order. *style* can be ``"plain"``, ``"latex"``, or ``"root"``.
+        uncertainty dict traversal order. *style* can be ``"plain"``, ``"fancy"``, ``"latex"``, or
+        ``"root"``.
 
         *styles* can be a dict with fields ``"space"``, ``"label"``, ``"unit"``, ``"sym"``,
         ``"asym"``, ``"sci"`` to customize every aspect of the format style on top of
@@ -643,19 +644,21 @@ class Number(object):
         .. code-block:: python
 
             n = Number(17.321, {"a": 1.158, "b": 0.453})
-            n.str()                    # -> '17.321 ±1.158 (a) ±0.453 (b)'
-            n.str("%.1f")              # -> '17.3 ±1.2 (a) ±0.5 (b)'
-            n.str("publication")       # -> '17.32 ±1.16 (a) ±0.45 (b)'
-            n.str("pdg")               # -> '17.3 ±1.2 (a) ±0.5 (b)'
+            n.str()                    # -> '17.321 +-1.158 (a) +-0.453 (b)'
+            n.str("%.1f")              # -> '17.3 +-1.2 (a) +-0.5 (b)'
+            n.str("publication")       # -> '17.32 +-1.16 (a) +-0.45 (b)'
+            n.str("pdg")               # -> '17.3 +-1.2 (a) +-0.5 (b)'
             n.str(combine_uncs="all")  # -> 'TODO'
 
             n = Number(8848, 10)
-            n.str(unit="m")                           # -> "8848.0 ±10.0 m"
+            n.str(unit="m")                           # -> "8848.0 +-10.0 m"
             n.str(unit="m", force_asymmetric=True)    # -> "8848.0 +10.0-10.0 m"
-            n.str(unit="m", scientific=True)          # -> "8.848 ±0.01 x 1E3 m"
-            n.str("%.2f", unit="m", scientific=True)  # -> "8.85 ±0.01 x 1E3 m"
-            n.str(unit="m", si=True)                  # -> "8.848 ±0.01 km"
-            n.str("%.2f", unit="m", si=True)          # -> "8.85 ±0.01 km"
+            n.str(unit="m", scientific=True)          # -> "8.848 +-0.01 x 1E3 m"
+            n.str("%.2f", unit="m", scientific=True)  # -> "8.85 +-0.01 x 1E3 m"
+            n.str(unit="m", si=True)                  # -> "8.848 +-0.01 km"
+            n.str("%.2f", unit="m", si=True)          # -> "8.85 +-0.01 km"
+            n.str(style="fancy")                      # -> "8848.0 ±10.0"
+            n.str(unit="m", style="fancy")            # -> "8848.0 ±10.0 m"
             n.str(unit="m", style="latex")            # -> "8848.0 \pm10.0\,m"
             n.str(unit="m", style="latex", si=True)   # -> "8.848 \pm0.01\,km"
             n.str(unit="m", style="root")             # -> "8848.0 #pm10.0 m"
@@ -734,7 +737,7 @@ class Number(object):
             # no uncertainties
             if len(names) == 0:
                 text += ending()
-                if style == "plain" and labels:
+                if style in ("plain", "fancy") and labels:
                     text += d["space"] + d["label"].format(label="no uncertainties")
 
             # one ore more uncertainties
@@ -1240,14 +1243,14 @@ class DeferredResult(object):
         n = Number(2, 5)
 
         n * Correlation(1) * n
-        # -> '25.0 ±20.0' (the default)
+        # -> '25.0 +-20.0' (the default)
 
         n * Correlation(0) * n
-        # -> '25.00 ±14.14'
+        # -> '25.00 +-14.14'
 
         # note the multiplication n * c, which creates the DeferredResult
         n**(n * c)
-        # -> '3125.00 ±11842.54'
+        # -> '3125.00 +-11842.54'
 
     .. py:attribute:: number
        type: Number
@@ -2610,10 +2613,10 @@ def create_hep_data_representer(method=None, force_asymmetric=False, force_float
     return representer
 
 
-#: Dictionaly containing formatting styles for ``"plain"``, ``"latex"`` and ``"root"`` styles which
-#: are used in :py:meth:`Number.str`. Each style dictionary contains 6 fields: ``"space"``,
-#: ``"label"``, ``"unit"``, ``"sym"``, ``"asym"``, and ``"sci"``. As an example, the plain style is
-#: configured as
+#: Dictionaly containing formatting styles for ``"plain"``, ``"fancy"``, ``"latex"`` and ``"root"``
+#: styles which are used in :py:meth:`Number.str`. Each style dictionary contains 6 fields:
+#: ``"space"``, ``"label"``, ``"unit"``, ``"sym"``, ``"asym"``, and ``"sci"``. As an example, the
+#: plain style is configured as
 #:
 #: .. code-block:: python
 #:
@@ -2621,12 +2624,20 @@ def create_hep_data_representer(method=None, force_asymmetric=False, force_float
 #:         "space": " ",
 #:         "label": "({label})",
 #:         "unit": " {unit}",
-#:         "sym": "±{unc}",
+#:         "sym": "+-{unc}",
 #:         "asym": "+{up}-{down}",
 #:         "sci": "x 1E{mag}",
 #:     }
 style_dict = {
     "plain": {
+        "space": " ",
+        "label": "({label})",
+        "unit": " {unit}",
+        "sym": "+-{unc}",
+        "asym": "+{up}-{down}",
+        "sci": "x 1E{mag}",
+    },
+    "fancy": {
         "space": " ",
         "label": "({label})",
         "unit": " {unit}",

--- a/scinum.py
+++ b/scinum.py
@@ -261,6 +261,13 @@ class Number(object):
         The default format string (``"%s"``) that is used in :py:meth:`str()` when no format string
         was passed.
 
+    .. py:classattribute:: default_style
+
+        type: string
+
+        The default style name (``"plain"``) that is used in :py:meth:`str()` when no style argument
+        was passed.
+
     .. py:classattribute:: DEFAULT
 
         type: string
@@ -378,8 +385,9 @@ class Number(object):
     D = DOWN
 
     default_format = "%s"
+    default_style = "plain"
 
-    def __init__(self, nominal=0.0, uncertainties=None, default_format=None):
+    def __init__(self, nominal=0.0, uncertainties=None, default_format=None, default_style=None):
         super(Number, self).__init__()
 
         # wrapped values
@@ -403,9 +411,13 @@ class Number(object):
             self.uncertainties = uncertainties
 
         self.default_format = default_format
+        self.default_style = default_style
 
     def _init_kwargs(self):
-        return {"default_format": self.default_format}
+        return {
+            "default_format": self.default_format,
+            "default_style": self.default_style,
+        }
 
     @typed
     def nominal(self, nominal):
@@ -610,7 +622,7 @@ class Number(object):
         scientific=False,
         si=False,
         labels=True,
-        style="plain",
+        style=None,
         styles=None,
         force_asymmetric=False,
         **kwargs  # noqa
@@ -632,7 +644,7 @@ class Number(object):
         *labels* controls whether uncertainty labels are shown in the string. When *True*,
         uncertainty names are used, but it can also be a list of labels whose order should match the
         uncertainty dict traversal order. *style* can be ``"plain"``, ``"fancy"``, ``"latex"``, or
-        ``"root"``.
+        ``"root"``. When *None* (the default), :py:attr:`default_style` is used.
 
         *styles* can be a dict with fields ``"space"``, ``"label"``, ``"unit"``, ``"sym"``,
         ``"asym"``, ``"sci"`` to customize every aspect of the format style on top of
@@ -666,6 +678,8 @@ class Number(object):
         """
         if format is None:
             format = self.default_format or self.__class__.default_format
+        if style is None:
+            style = self.default_style or self.__class__.default_style
 
         # when uncertainties should be combined, create a new instance and forward to its formatting
         if combine_uncs:

--- a/tests/test_number.py
+++ b/tests/test_number.py
@@ -149,22 +149,30 @@ class TestCase(unittest.TestCase):
         self.assertEqual(num.u(direction=UP).shape, (3,))
 
     def test_string_formats(self):
-        self.assertEqual(len(self.num.str()), 105)
-        self.assertEqual(len(self.num.str("%.3f")), 129)
-        self.assertEqual(len(self.num.str(lambda n: "%s" % n)), 105)
-        self.assertEqual(len(self.num.str(lambda n: "X%s" % n)), 119)
-        self.assertEqual(len(self.num.repr().split(" ", 3)[-1]), 108)
-        self.assertEqual(len(self.num.str(2)), 115)
-        self.assertEqual(len(self.num.str(3)), 129)
-        self.assertEqual(len(self.num.str(4)), 143)
-        self.assertEqual(len(self.num.str(-1)), 101)
-        self.assertEqual(len(self.num.str("pub")), 129)
-        self.assertEqual(len(self.num.str("publication")), 129)
-        self.assertEqual(len(self.num.str("pdg")), 115)
-        self.assertEqual(len(self.num.str("pdg+1")), 129)
+        self.assertEqual(len(self.num.str()), 102)
+        self.assertEqual(len(self.num.str("%.3f")), 126)
+        self.assertEqual(len(self.num.str(lambda n: "%s" % n)), 102)
+        self.assertEqual(len(self.num.str(lambda n: "X%s" % n)), 116)
+        self.assertEqual(len(self.num.repr().split(" ", 3)[-1]), 105)
+        self.assertEqual(len(self.num.str(2)), 112)
+        self.assertEqual(len(self.num.str(3)), 126)
+        self.assertEqual(len(self.num.str(4)), 140)
+        self.assertEqual(len(self.num.str(-1)), 98)
+        self.assertEqual(len(self.num.str("pub")), 126)
+        self.assertEqual(len(self.num.str("publication")), 126)
+        self.assertEqual(len(self.num.str("pdg")), 112)
+        self.assertEqual(len(self.num.str("pdg+1")), 126)
 
         with self.assertRaises(ValueError):
             self.num.str("foo")
+
+        self.assertEqual(len(self.num.str(style="fancy")), 99)
+        self.assertEqual(len(self.num.str(style="root")), 223)
+        self.assertEqual(len(self.num.str(style="latex")), 289)
+        self.assertEqual(len(self.num.str()), 102)
+        self.num.default_style = "fancy"
+        self.assertEqual(len(self.num.str()), 99)
+        self.num.default_style = "plain"
 
         num = self.num.copy()
         num.uncertainties = {}
@@ -177,20 +185,20 @@ class TestCase(unittest.TestCase):
         n = Number(8848, {"stat": (30, 20)})
         n.set_uncertainty("syst", (Number.REL, 0.5))
 
-        self.assertEqual(n.str(), "8848.0 +30.0-20.0 (stat) +- 4424.0 (syst)")
-        self.assertEqual(n.str(scientific=True), "8.848 +0.03-0.02 (stat) +- 4.424 (syst) x 1E3")
+        self.assertEqual(n.str(), "8848.0 +30.0-20.0 (stat) +-4424.0 (syst)")
+        self.assertEqual(n.str(scientific=True), "8.848 +0.03-0.02 (stat) +-4.424 (syst) x 1E3")
         self.assertEqual(n.str(scientific=True, unit="m"),
-            "8.848 +0.03-0.02 (stat) +- 4.424 (syst) x 1E3 m")
-        self.assertEqual(n.str(si=True), "8.848 +0.03-0.02 (stat) +- 4.424 (syst) k")
-        self.assertEqual(n.str(si=True, unit="m"), "8.848 +0.03-0.02 (stat) +- 4.424 (syst) km")
-        self.assertEqual(n.str("%.2f", si=True), "8.85 +0.03-0.02 (stat) +- 4.42 (syst) k")
-        self.assertEqual(n.str(-2, si=True), "8.85 +0.03-0.02 (stat) +- 4.42 (syst) k")
+            "8.848 +0.03-0.02 (stat) +-4.424 (syst) x 1E3 m")
+        self.assertEqual(n.str(si=True), "8.848 +0.03-0.02 (stat) +-4.424 (syst) k")
+        self.assertEqual(n.str(si=True, unit="m"), "8.848 +0.03-0.02 (stat) +-4.424 (syst) km")
+        self.assertEqual(n.str("%.2f", si=True), "8.85 +0.03-0.02 (stat) +-4.42 (syst) k")
+        self.assertEqual(n.str(-2, si=True), "8.85 +0.03-0.02 (stat) +-4.42 (syst) k")
 
-        self.assertEqual(n.str("%.3f", si=True), "8.848 +0.030-0.020 (stat) +- 4.424 (syst) k")
-        self.assertEqual(n.str(-3, si=False), "8848.000 +30.000-20.000 (stat) +- 4424.000 (syst)")
-        self.assertEqual(n.str(-3, si=True), "8.848 +0.030-0.020 (stat) +- 4.424 (syst) k")
-        self.assertEqual(n.str(3, si=False), "8848.0 +30.0-20.0 (stat) +- 4424.0 (syst)")
-        self.assertEqual(n.str("pdg", si=False), "8848 +30-20 (stat) +- 4000 (syst)")
+        self.assertEqual(n.str("%.3f", si=True), "8.848 +0.030-0.020 (stat) +-4.424 (syst) k")
+        self.assertEqual(n.str(-3, si=False), "8848.000 +30.000-20.000 (stat) +-4424.000 (syst)")
+        self.assertEqual(n.str(-3, si=True), "8.848 +0.030-0.020 (stat) +-4.424 (syst) k")
+        self.assertEqual(n.str(3, si=False), "8848.0 +30.0-20.0 (stat) +-4424.0 (syst)")
+        self.assertEqual(n.str("pdg", si=False), "8848 +30-20 (stat) +-4000 (syst)")
 
     def test_uncertainty_parsing(self):
         uncs = {}
@@ -373,7 +381,7 @@ class TestCase(unittest.TestCase):
         self.assertEqual(n1.str(format=3), "8848.0 +37.4-30.0")
 
         n2 = n.combine_uncertaintes({"x": ["stat", "syst"]})
-        self.assertEqual(n2.str(format=3), "8848.0 +36.1-28.3 (x) +- 10.0 (other)")
+        self.assertEqual(n2.str(format=3), "8848.0 +36.1-28.3 (x) +-10.0 (other)")
 
         n3 = n.combine_uncertaintes(OrderedDict([("x", ["stat", "syst"]), ("y", "all")]))
         self.assertEqual(n3.str(format=3), "8848.0 +36.1-28.3 (x) +37.4-30.0 (y)")


### PR DESCRIPTION
This PR is a follow-up of #15 by @adavidzh.

- Adds a new "fancy" style using unicode character "±" instead of "+-"
- Removes the space behind the "±" or "+-" for consistency.
- Drops python 2.7 tests as there are no longer supported by the "setup-python" GH action.
- Adjust tests.